### PR TITLE
Release the current gh-pages branch to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+secrets.tfvars
+terraform.tfstate
+terraform.tfstate.backup
+.terraform

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# www.gormonjee.com
+
+Public website for the Gormonjee health and nutrition initiative.
+
+## Development
+
+The website at present is a single page, stored in `index.html` with css in
+`style.css` and images in the `images` folder.
+
+DNS is managed using [Terraform](https://www.terraform.io/) with the
+[Cloudflare Provider](https://www.terraform.io/docs/providers/cloudflare/index.html)
+
+## Deployment
+
+The website auto-deploys on pushes to the `gh-pages` branch.

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,0 +1,38 @@
+variable "cloudflare_email" {
+  type = string
+}
+
+
+variable "cloudflare_api_key" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+  default = "2146e73eda755e4e0120758e1de41880"
+}
+
+provider "cloudflare" {
+  version = "~> 2.0"
+  email   = var.cloudflare_email
+  api_key = var.cloudflare_api_key
+}
+
+# Create a record
+resource "cloudflare_record" "www" {
+  zone_id = var.cloudflare_zone_id
+  name    = "www"
+  value   = "zinc-collective.github.io"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_record" "gormonjee-com" {
+  zone_id = var.cloudflare_zone_id
+  name    = "gormonjee.com"
+  value   = "www.gormonjee.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+}

--- a/secrets.example.tfvars
+++ b/secrets.example.tfvars
@@ -1,0 +1,2 @@
+cloudflare_email   = "get-this-from-cloudflare"
+cloudflare_api_key = "get-this-from-cloudflare"


### PR DESCRIPTION
See: https://github.com/zinc-collective/www.gormonjee.com/issues/1

This updates www.gormonjee.com to point to the landing page being 
developed in the repository.

It does so by adding an infrastructure.tf file and secrets.example.tfvars file
so the DNS management is canonicized in the repository and changes can
be tracked with version control.